### PR TITLE
Don't swallow exceptions

### DIFF
--- a/lib/zester/resource.rb
+++ b/lib/zester/resource.rb
@@ -8,11 +8,7 @@ module Zester
     end
 
     def get_results(endpoint, resource_type, params = {})
-      begin
-        Response.new(self.client.perform_get(endpoint, params), resource_type)
-      rescue Timeout::Error, Exception
-        Response.new({resource_type => {:message => {:code => "3", :text => "Web services are currently unavailable"}}}, resource_type)
-      end
+      Response.new(self.client.perform_get(endpoint, params), resource_type)
     end
 
   end

--- a/spec/zester/resource_spec.rb
+++ b/spec/zester/resource_spec.rb
@@ -26,13 +26,9 @@ describe Zester::Resource do
       VCR.turn_on!
     end
 
-    it "should rescue a timeout error" do
+    it "should not rescue a timeout error" do
       stub_request(:get, "http://www.zillow.com/webservice/GetRateSummary.htm?zws-id=#{ZWS_ID}").to_timeout
-      response = resource.get_results('GetRateSummary', :rate_summary)
-      response.success?.should be_false
-      response.message.should_not be_nil
-      response.message.code.should == "3"
-      response.response_code.should == 3
+      expect {get_response}.to raise_error(Timeout::Error)
     end
   end
 


### PR DESCRIPTION
While it's arguably for rescuing timeouts, it's wrong to swallow all
exceptions.

For example, I spent about an hour figuring out why webmock doesn't work
for zester, while it worked everywhere else. By default, webmock disables
all http requests, and raises exceptions with suggestion to mock it. But
in case with zester, it returned just `Web services are currently
unavailable`, which was really weird: webmock seemed not working and API
call was made, but Zillow returned an error about unavailability.
After all I had to debug to this method.

If exceptions were not swallowed, it was clear where the problem is.